### PR TITLE
Walkthrough 2.0

### DIFF
--- a/walkthroughs/1-ionic-showcase/walkthrough.adoc
+++ b/walkthroughs/1-ionic-showcase/walkthrough.adoc
@@ -34,7 +34,45 @@ image::images/arch.png[architecture, role="integr8ly-img-responsive"]
 * link:https://access.redhat.com/documentation/en-us/red_hat_managed_integration/1/html-single/developing_a_data_sync_app/index[Getting Started with {data-sync-name}, window="_blank"]
 ****
 
+[type=walkthroughResource,serviceName=codeready]
+.CodeReady Workspaces
+****
+* link:{che-url}[Console, window="_blank"]
+* link:https://developers.redhat.com/products/codeready-workspaces/overview/[Overview, window="_blank"]
+* link:https://access.redhat.com/documentation/en-us/red_hat_codeready_workspaces_for_openshift/1.0.0/[Documentation, window="_blank"]
+****
+
+
 :sectnums:
+
+[time=10]
+== Build and run the mobile showcase app in a browser
+
+The showcase app demonstrates the key capabilities provided by {mobile-services-name}.
+It can run either as a hybrid mobile application, or a Progressive Web App (PWA).
+
+In this task, you build a PWA and run it in a browser.
+
+. Login to link:{che-url}[CodeReady Console, window="_blank"].
+. Download this link:https://raw.githubusercontent.com/aerogear/ionic-showcase/master/.factory.json[Showcase template JSON file, window="_blank"].
+. Select *Factories* from the left hand menu.
+. Click *Create Factory* if prompted.
+. Enter the following as the *Name*:
++
+----
+showcase-app
+----
+. In the *Source* section, select the *Config* tab.
+
+. Click *Upload File* and upload the file you downloaded in step 2.
+
+. Select *Create*.
+This creates a new CodeReady workspace named `ionic-showcase`.
+
+. Click *OPEN* to navigate to the `ionic-showcase` workspace.
+Initializing and starting the workspace can take a few minutes.
+
+// TODO this section bellow will be oudated
 
 [time=10]
 == Deploying the Data Sync showcase application


### PR DESCRIPTION
## Motivation

Purpose of this PR is to discuss and build new mobile walkthrough based on code ready and streamline collaboration on the walkthrough

## What we have now

1. Showcase is now represented as a single container build and tested by our team that is being used inside OpenShift template. We moved to this workflow to:

- Simplify the maintenance of the walkthrough (as this doubles number of steps)
- In many cases, we received issues with a walkthrough that were code ready specific. 

Moving to OpenShift 4.0 and using Eclipse Che will require significant changes in workflow.
Our walkthrough showcases data sync features 

2. As base now we will need to get showcase codebase into CodeReady.
Build client-side applications using the predefined command. Then build and deploy the server into node.js container. This container host both the ionic app and the server for simplicity and a smaller footprint. 


## Ideas

1. Go with building client and server applications and deploying it from scratch - which could be error-prone and cause some issues. The classical build app experience

2. Use base image that already has an app and then simply builds some very small layer on top of it that will contain small client modifications (configs etc.)

3. Hide fact that user code will be used in the deployment and deploy the predefined containers. This way if eclipe che steps will fail people will still be able to play with the app etc. 